### PR TITLE
Only google3 friendly deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleipnir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Memory safe font operations for Google Fonts."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-kurbo = "0.10.4"
+kurbo = "0.11.0"
 skrifa = "0.18.0"
 
 smol_str = "0.2.1"
 thiserror = "1.0.57"
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -90,7 +90,6 @@ mod tests {
         iconid::{self, IconIdentifier},
         testdata_bytes, testdata_string,
     };
-    use pretty_assertions::assert_eq;
     use skrifa::{instance::Location, FontRef, MetadataProvider};
 
     use super::DrawOptions;


### PR DESCRIPTION
Update to kurbo that google3 has. Remove pretty_assertions that google3 hasn't.

Bump patch to prep for release

JMM