### PR TITLE
Adjust testdata to compiled in like fontations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleipnir"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Memory safe font operations for Google Fonts."

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -88,16 +88,15 @@ mod tests {
     use crate::{
         icon2svg::draw_icon,
         iconid::{self, IconIdentifier},
-        testdata_bytes, testdata_string,
+        testdata,
     };
     use skrifa::{instance::Location, FontRef, MetadataProvider};
 
     use super::DrawOptions;
 
     // Matches tests in code to be replaced
-    fn assert_draw_icon(expected_file: &str, identifier: IconIdentifier) {
-        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
-        let font = FontRef::new(&raw_font).unwrap();
+    fn assert_draw_icon(expected_svg: &str, identifier: IconIdentifier) {
+        let font = FontRef::new(testdata::ICON_FONT).unwrap();
         let loc = font.axes().location(&[
             ("wght", 400.0),
             ("opsz", 24.0),
@@ -106,37 +105,33 @@ mod tests {
         ]);
         let options = DrawOptions::new(identifier, 24.0, (&loc).into());
 
-        assert_eq!(
-            testdata_string(expected_file),
-            draw_icon(&font, &options).unwrap()
-        );
+        assert_eq!(expected_svg, draw_icon(&font, &options).unwrap());
     }
 
     #[test]
     fn draw_mail_icon() {
-        assert_draw_icon("mail.svg", iconid::MAIL.clone());
+        assert_draw_icon(testdata::MAIL_SVG, iconid::MAIL.clone());
     }
 
     #[test]
     fn draw_lan_icon() {
-        assert_draw_icon("lan.svg", iconid::LAN.clone());
+        assert_draw_icon(testdata::LAN_SVG, iconid::LAN.clone());
     }
 
     #[test]
     fn draw_man_icon() {
-        assert_draw_icon("man.svg", iconid::MAN.clone());
+        assert_draw_icon(testdata::MAN_SVG, iconid::MAN.clone());
     }
 
     #[test]
     fn draw_mostly_off_curve() {
-        let raw_font = testdata_bytes("mostly_off_curve.ttf");
-        let font = FontRef::new(&raw_font).unwrap();
+        let font = FontRef::new(testdata::MOSTLY_OFF_CURVE_FONT).unwrap();
         let loc = Location::default();
         let identifier = IconIdentifier::Codepoint(0x2e);
         let options = DrawOptions::new(identifier, 24.0, (&loc).into());
 
         assert_eq!(
-            testdata_string("mostly_off_curve.svg"),
+            testdata::MOSTLY_OFF_CURVE_SVG,
             draw_icon(&font, &options).unwrap()
         );
     }

--- a/src/iconid.rs
+++ b/src/iconid.rs
@@ -235,7 +235,7 @@ mod tests {
 
     use crate::{
         iconid::{LAN, MAIL, MAN},
-        testdata_bytes,
+        testdata,
     };
 
     use super::IconIdentifier;
@@ -245,8 +245,7 @@ mod tests {
         I: IntoIterator,
         I::Item: Into<VariationSetting>,
     {
-        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
-        let font = FontRef::new(&raw_font).unwrap();
+        let font = FontRef::new(testdata::ICON_FONT).unwrap();
         let location = font.axes().location(location);
         assert_eq!(
             expected,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,24 +3,17 @@ pub mod icon2svg;
 pub mod iconid;
 mod pens;
 
+/// Setup to match fontations/font-test-data because that rig works for google3
 #[cfg(test)]
-pub(crate) fn testdata_dir() -> std::path::PathBuf {
-    use std::{path::PathBuf, str::FromStr};
-    PathBuf::from_str("resources/testdata").unwrap()
-}
+mod testdata {
+    pub static LAN_SVG: &str = include_str!("../resources/testdata/lan.svg");
+    pub static MAN_SVG: &str = include_str!("../resources/testdata/man.svg");
+    pub static MAIL_SVG: &str = include_str!("../resources/testdata/mail.svg");
+    pub static MOSTLY_OFF_CURVE_SVG: &str =
+        include_str!("../resources/testdata/mostly_off_curve.svg");
 
-#[cfg(test)]
-pub(crate) fn testdata_string(path: &str) -> String {
-    use std::fs;
-
-    let path = testdata_dir().join(path);
-    fs::read_to_string(&path).unwrap_or_else(|e| panic!("Unable to read {path:?}: {e}"))
-}
-
-#[cfg(test)]
-pub(crate) fn testdata_bytes(path: &str) -> Vec<u8> {
-    use std::fs;
-
-    let path = testdata_dir().join(path);
-    fs::read(&path).unwrap_or_else(|e| panic!("Unable to read {path:?}: {e}"))
+    pub static ICON_FONT: &[u8] =
+        include_bytes!("../resources/testdata/vf[FILL,GRAD,opsz,wght].ttf");
+    pub static MOSTLY_OFF_CURVE_FONT: &[u8] =
+        include_bytes!("../resources/testdata/mostly_off_curve.ttf");
 }


### PR DESCRIPTION
Consistency (with https://github.com/googlefonts/fontations/blob/main/font-test-data/src/lib.rs) is nice and the fontations rig works on google3

JMM