### PR TITLE
First steps towards emitting a mildly compact path

### DIFF
--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -1,6 +1,6 @@
 //! Produces svgs of icons in Google-style icon fonts
 
-use crate::{error::DrawSvgError, iconid::IconIdentifier, pens::SvgPathPen};
+use crate::{error::DrawSvgError, iconid::IconIdentifier, pathstyle::PathStyle, pens::SvgPathPen};
 use skrifa::{
     instance::{LocationRef, Size},
     outline::DrawSettings,
@@ -53,7 +53,7 @@ pub fn draw_icon(font: &FontRef, options: &DrawOptions<'_>) -> Result<String, Dr
 
     // the actual path
     svg.push_str("<path d=\"");
-    svg.push_str(&svg_path_pen.to_svg_path());
+    svg.push_str(&options.style.write_svg_path(&svg_path_pen.into_inner()));
     //svg.push_str(&path_pen.into_inner().to_svg());
     svg.push_str("\"/>");
 
@@ -67,6 +67,7 @@ pub struct DrawOptions<'a> {
     identifier: IconIdentifier,
     width_height: f32,
     location: LocationRef<'a>,
+    style: PathStyle,
 }
 
 impl<'a> DrawOptions<'a> {
@@ -74,11 +75,13 @@ impl<'a> DrawOptions<'a> {
         identifier: IconIdentifier,
         width_height: f32,
         location: LocationRef<'a>,
+        style: PathStyle,
     ) -> DrawOptions<'a> {
         DrawOptions {
             identifier,
             width_height,
             location,
+            style,
         }
     }
 }
@@ -88,6 +91,7 @@ mod tests {
     use crate::{
         icon2svg::draw_icon,
         iconid::{self, IconIdentifier},
+        pathstyle::PathStyle,
         testdata,
     };
     use regex::Regex;
@@ -121,7 +125,7 @@ mod tests {
             ("GRAD", 0.0),
             ("FILL", 1.0),
         ]);
-        let options = DrawOptions::new(identifier, 24.0, (&loc).into());
+        let options = DrawOptions::new(identifier, 24.0, (&loc).into(), PathStyle::Unoptimized);
 
         assert_icon_svg_equal(expected_svg, &draw_icon(&font, &options).unwrap());
     }
@@ -140,7 +144,12 @@ mod tests {
             ("GRAD", 200.0),
             ("FILL", 1.0),
         ]);
-        let options = DrawOptions::new(iconid::MAIL.clone(), 48.0, (&loc).into());
+        let options = DrawOptions::new(
+            iconid::MAIL.clone(),
+            48.0,
+            (&loc).into(),
+            PathStyle::Unoptimized,
+        );
 
         assert_icon_svg_equal(
             testdata::MAIL_OPSZ48_SVG,
@@ -163,7 +172,7 @@ mod tests {
         let font = FontRef::new(testdata::MOSTLY_OFF_CURVE_FONT).unwrap();
         let loc = Location::default();
         let identifier = IconIdentifier::Codepoint(0x2e);
-        let options = DrawOptions::new(identifier, 24.0, (&loc).into());
+        let options = DrawOptions::new(identifier, 24.0, (&loc).into(), PathStyle::Unoptimized);
 
         assert_icon_svg_equal(
             testdata::MOSTLY_OFF_CURVE_SVG,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod icon2svg;
 pub mod iconid;
+mod pathstyle;
 mod pens;
 
 /// Setup to match fontations/font-test-data because that rig works for google3

--- a/src/pathstyle.rs
+++ b/src/pathstyle.rs
@@ -1,0 +1,214 @@
+//! Controls how a [`BezPath`] is converted to string form.
+
+use kurbo::{BezPath, PathEl, Point};
+
+#[derive(Debug, Copy, Clone)]
+pub enum PathStyle {
+    /// Make no effort to produce a compact path
+    Unoptimized,
+    /// Try to produce a compact path, applying roughly the same optimizations as [svgo convertPathData.js](https://github.com/svg/svgo/blob/main/plugins/convertPathData.js)
+    Compact,
+}
+
+impl PathStyle {
+    pub(crate) fn write_svg_path(&self, path: &BezPath) -> String {
+        match self {
+            PathStyle::Unoptimized => to_unoptimized_svg_path(path),
+            PathStyle::Compact => to_compact_svg_path(path),
+        }
+    }
+}
+
+fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+trait ToSvgCoord {
+    fn write_absolute_coord(&self) -> String;
+    fn write_relative_coord(&self, other: Self) -> String;
+}
+
+impl ToSvgCoord for f64 {
+    fn write_absolute_coord(&self) -> String {
+        format!("{}", round2(*self))
+    }
+
+    fn write_relative_coord(&self, other: Self) -> String {
+        format!("{}", round2(*self - other))
+    }
+}
+
+impl ToSvgCoord for Point {
+    fn write_absolute_coord(&self) -> String {
+        coord_string(*self)
+    }
+
+    fn write_relative_coord(&self, other: Self) -> String {
+        coord_string((*self - other).to_point())
+    }
+}
+
+fn coord_string(p: Point) -> String {
+    format!("{},{}", round2(p.x), round2(p.y))
+}
+
+fn add_command<T, const N: usize>(
+    svg: &mut String,
+    prefix: char,
+    coords: [T; N],
+    relative_to: Option<T>,
+) where
+    T: ToSvgCoord + Copy,
+{
+    assert!(prefix.is_ascii_uppercase());
+
+    let absolute = coords
+        .iter()
+        .map(|p| p.write_absolute_coord())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let relative = relative_to.map(|rel_to| {
+        coords
+            .iter()
+            .map(|p| p.write_relative_coord(rel_to))
+            .collect::<Vec<_>>()
+            .join(" ")
+    });
+
+    if relative.as_ref().map(|s| s.len()).unwrap_or(usize::MAX) < absolute.len() {
+        svg.push(prefix.to_ascii_lowercase());
+        svg.push_str(&relative.unwrap());
+    } else {
+        svg.push(prefix);
+        svg.push_str(&absolute);
+    }
+}
+
+fn to_unoptimized_svg_path(path: &BezPath) -> String {
+    let mut svg = String::new();
+    let mut subpath_start = Point::default();
+    let mut curr = Point::default();
+    for el in path.elements() {
+        match el {
+            PathEl::MoveTo(p) => {
+                add_command(&mut svg, 'M', [*p], None);
+                subpath_start = *p;
+                curr = *p;
+            }
+            PathEl::LineTo(p) => {
+                add_command(&mut svg, 'L', [*p], None);
+                curr = *p;
+            }
+            PathEl::QuadTo(p1, p2) => {
+                add_command(&mut svg, 'Q', [*p1, *p2], None);
+                curr = *p2;
+            }
+            PathEl::CurveTo(p1, p2, p3) => {
+                add_command(&mut svg, 'C', [*p1, *p2, *p3], None);
+                curr = *p3;
+            }
+            PathEl::ClosePath => {
+                // See <https://github.com/harfbuzz/harfbuzz/blob/2da79f70a1d562d883bdde5b74f6603374fb7023/src/hb-draw.hh#L148-L150>
+                if curr != subpath_start {
+                    add_command(&mut svg, 'L', [subpath_start], None);
+                }
+                svg.push('Z')
+            }
+        }
+    }
+    svg
+}
+
+fn compact_line_to(svg: &mut String, p: Point, curr: Point) {
+    if p.x == curr.x {
+        add_command(svg, 'V', [p.y], Some(curr.y));
+    } else if p.y == curr.y {
+        add_command(svg, 'H', [p.x], Some(curr.x));
+    } else {
+        add_command(svg, 'L', [p], Some(curr));
+    }
+}
+
+fn to_compact_svg_path(path: &BezPath) -> String {
+    let mut svg = String::new();
+    let mut subpath_start = Point::default();
+    let mut curr = Point::default();
+    for el in path.elements() {
+        match el {
+            PathEl::MoveTo(p) => {
+                add_command(&mut svg, 'M', [*p], Some(curr));
+                subpath_start = *p;
+                curr = *p;
+            }
+            PathEl::LineTo(p) => {
+                compact_line_to(&mut svg, *p, curr);
+                curr = *p;
+            }
+            PathEl::QuadTo(p1, p2) => {
+                add_command(&mut svg, 'Q', [*p1, *p2], Some(curr));
+                curr = *p2;
+            }
+            PathEl::CurveTo(p1, p2, p3) => {
+                add_command(&mut svg, 'C', [*p1, *p2, *p3], Some(curr));
+                curr = *p3;
+            }
+            PathEl::ClosePath => {
+                // See <https://github.com/harfbuzz/harfbuzz/blob/2da79f70a1d562d883bdde5b74f6603374fb7023/src/hb-draw.hh#L148-L150>
+                if curr != subpath_start {
+                    compact_line_to(&mut svg, subpath_start, curr);
+                }
+                svg.push('Z')
+            }
+        }
+    }
+    svg
+}
+
+#[cfg(test)]
+mod tests {
+    use kurbo::BezPath;
+
+    use crate::pathstyle::PathStyle;
+
+    #[test]
+    fn compact_1d_lines() {
+        let mut path = BezPath::new();
+        path.move_to((1.0, 1.0));
+        path.line_to((2.0, 2.0));
+        path.line_to((3.0, 2.0));
+        path.line_to((3.0, 3.0));
+        path.line_to((1.25, 3.0));
+        path.line_to((1.25, 1.5));
+        path.close_path();
+
+        assert_eq!(
+            PathStyle::Unoptimized.write_svg_path(&path),
+            "M1,1L2,2L3,2L3,3L1.25,3L1.25,1.5L1,1Z"
+        );
+        assert_eq!(
+            PathStyle::Compact.write_svg_path(&path),
+            "M1,1L2,2H3V3H1.25V1.5L1,1Z"
+        );
+    }
+
+    #[test]
+    fn relative_when_shorter() {
+        let mut path = BezPath::new();
+        path.move_to((10.0, 10.0));
+        path.line_to((11.0, 11.0));
+        path.quad_to((15.0, 19.0), (20.0, 20.0));
+        path.line_to((19.0, 20.0));
+        path.line_to((19.0, 19.0));
+        path.curve_to((23.0, 17.0), (12.0, 14.0), (10.0, 11.0));
+        path.close_path();
+
+        assert_eq!(
+            PathStyle::Unoptimized.write_svg_path(&path),
+            "M10,10L11,11Q15,19 20,20L19,20L19,19C23,17 12,14 10,11L10,10Z"
+        );
+        assert_eq!(
+            PathStyle::Compact.write_svg_path(&path),
+            "M10,10l1,1q4,8 9,9H19V19c4,-2 -7,-5 -9,-8V10Z"
+        );
+    }
+}

--- a/src/pens.rs
+++ b/src/pens.rs
@@ -1,73 +1,27 @@
 //! Our own transformed bezier pen to avoid a dependency on write-fonts which is not in google3
 
-use kurbo::{Affine, BezPath, PathEl, Point};
+use kurbo::{BezPath, Point};
 use skrifa::outline::OutlinePen;
-use std::fmt::Write;
 
 /// Produces an svg representation of a font glyph corrected to be Y-down (as in svg) instead of Y-up (as in fonts)
 pub(crate) struct SvgPathPen {
-    transform: Affine,
     path: BezPath,
-}
-
-fn round2(v: f64) -> f64 {
-    (v * 100.0).round() / 100.0
-}
-
-fn push_point(svg: &mut String, prefix: char, p: Point) {
-    svg.push(prefix);
-    write!(svg, "{},{}", round2(p.x), round2(p.y)).expect("We can't write into a String?!");
 }
 
 impl SvgPathPen {
     pub(crate) fn new() -> Self {
         Self {
-            transform: Affine::FLIP_Y, // svg is Y-down, fonts are Y-up
             path: Default::default(),
         }
     }
 
     fn to_svg_units(&self, x: f32, y: f32) -> Point {
-        self.transform * Point::new(x as f64, y as f64)
+        // svg is Y-down, fonts are Y-up
+        Point::new(x as f64, -y as f64)
     }
 
-    pub(crate) fn to_svg_path(&self) -> String {
-        // We use this rather than [`BezPath::to_svg`]` so we can exactly match the output of the tool we seek to replace
-        let mut svg = String::new();
-        let mut subpath_start = Point::default();
-        let mut curr = Point::default();
-        for el in self.path.elements() {
-            match el {
-                PathEl::MoveTo(p) => {
-                    push_point(&mut svg, 'M', *p);
-                    subpath_start = *p;
-                    curr = *p;
-                }
-                PathEl::LineTo(p) => {
-                    push_point(&mut svg, 'L', *p);
-                    curr = *p;
-                }
-                PathEl::QuadTo(p1, p2) => {
-                    push_point(&mut svg, 'Q', *p1);
-                    push_point(&mut svg, ' ', *p2);
-                    curr = *p2;
-                }
-                PathEl::CurveTo(p1, p2, p3) => {
-                    push_point(&mut svg, 'C', *p1);
-                    push_point(&mut svg, ' ', *p2);
-                    push_point(&mut svg, ' ', *p3);
-                    curr = *p3;
-                }
-                PathEl::ClosePath => {
-                    // See <https://github.com/harfbuzz/harfbuzz/blob/2da79f70a1d562d883bdde5b74f6603374fb7023/src/hb-draw.hh#L148-L150>
-                    if curr != subpath_start {
-                        push_point(&mut svg, 'L', subpath_start);
-                    }
-                    svg.push('Z')
-                }
-            }
-        }
-        svg
+    pub(crate) fn into_inner(self) -> BezPath {
+        self.path
     }
 }
 


### PR DESCRIPTION
Start of #18, add optional icon path optimization, implement use of line shorthands and relative coords when shorter.