### PR TITLE
Convert panics into errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ harfrust = "0.1.2"
 png = "0.17.16"
 tiny-skia = "0.11.4"
 roxmltree = "0.20"
-read-fonts = "0.33.1"
 regex = "1"
 
 [dev-dependencies]

--- a/src/text2png.rs
+++ b/src/text2png.rs
@@ -1,9 +1,9 @@
 //! renders text into png, forked from <https://github.com/rsheeter/embed1/blob/main/make_test_images/src/main.rs>
 use kurbo::{Affine, BezPath, PathEl, Rect, Shape, Vec2};
-use read_fonts::{FontRef, ReadError};
 use skrifa::{
     outline::DrawSettings,
     prelude::{LocationRef, Size},
+    raw::{FontRef, ReadError},
     MetadataProvider,
 };
 use thiserror::Error;
@@ -17,8 +17,10 @@ pub enum TextToPngError {
     ReadError(#[from] ReadError),
     #[error("error encoding bitmap to png: {0}")]
     PngEncodingError(#[from] png::EncodingError),
-    #[error("there was no text to render, either an empty string or the font size was too small")]
+    #[error("there was no text to render")]
     NoText,
+    #[error("the combination of text and font size was too small to produce anything")]
+    TextTooSmall,
     #[error("Failed to build render path")]
     PathBuildError,
 }
@@ -102,7 +104,7 @@ pub fn text2png(
     let y_offset = (expected_height - bbox.height()) / 2.0;
 
     let mut pixmap = Pixmap::new(bbox.width().ceil() as u32, expected_height as u32)
-        .ok_or(TextToPngError::NoText)?;
+        .ok_or(TextToPngError::TextTooSmall)?;
 
     // https://github.com/linebender/tiny-skia/blob/main/examples/fill.rs basically
     pixmap.fill(background);


### PR DESCRIPTION
- Breaking change: text2png returns a new error type
  - Should be fine as current caller only expects the error implement Display which is required for [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html)