### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,24 @@ on:
 
 name: Continuous integration
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - run: rustup component add rustfmt
 
       - name: rustfmt check
@@ -32,9 +43,13 @@ jobs:
     name: Clippy lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: cargo clippy --all-features
         run: cargo clippy --all-features --all-targets -- -D warnings
@@ -46,10 +61,14 @@ jobs:
     name: cargo test stable
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       # test all packages individually to ensure deterministic resolution
       # of dependencies for each package
@@ -61,10 +80,14 @@ jobs:
     name: cargo check no std
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: cargo check
         run: cargo check --manifest-path=Cargo.toml --no-default-features
@@ -73,11 +96,14 @@ jobs:
     name: cargo check wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - run: rustup target add wasm32-unknown-unknown
       - name: cargo check wasm target
         run: cargo check --manifest-path=Cargo.toml --target wasm32-unknown-unknown
-

--- a/src/iconid.rs
+++ b/src/iconid.rs
@@ -246,7 +246,7 @@ impl Icons for FontRef<'_> {
         let mut icons: Vec<(GlyphId, String)> = single_charc_icons
             .chain(icons)
             .collect::<Result<Vec<_>, _>>()?;
-        icons.sort_by(|a, b| a.0.cmp(&b.0));
+        icons.sort_by_key(|a| a.0);
         icons
             .chunk_by(|a, b| a.0 == b.0)
             .map(|group| {

--- a/src/pens.rs
+++ b/src/pens.rs
@@ -18,6 +18,12 @@ pub struct SvgPathPen {
     transform: Affine,
 }
 
+impl Default for SvgPathPen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SvgPathPen {
     pub fn new() -> Self {
         SvgPathPen {


### PR DESCRIPTION
- cargo clippy warning is fixed
- Pin GitHub action versions as recommended by the Zizmor checks.